### PR TITLE
allow mixed models

### DIFF
--- a/darkelf/__init__.py
+++ b/darkelf/__init__.py
@@ -181,7 +181,7 @@ class darkelf(object):
     from .phonon import R_phonon, dRdomega_phonon, dRdomegadk_phonon
 
     from .Migdal import load_Migdal_FAC, _I, _J, _incomErf
-    from .Migdal import dPdomega, dPdomegadk, dRdEn_nuclear, dRdomega_migdal, R_migdal, tabulate_I
+    from .Migdal import dPdomega, dPdomegadk, dRdEn_nuclear, dRdomega_migdal, R_migdal, tabulate_I, dRdomega_migdal_mixed
 
     from .absorption import R_absorption
 


### PR DESCRIPTION
Add function `dRdomega_migdal_mixed` that allows mixing the Lindhard and grid models as recoil energies > 70 eV would otherwise not be modelled since it is not included in the GPAW method (https://arxiv.org/pdf/2104.12786.pdf):

![afbeelding](https://user-images.githubusercontent.com/22295914/181775737-f41ed0c8-e352-4838-866b-de806f84d8b6.png)
